### PR TITLE
Finishing SignInActivity after a successfully signin

### DIFF
--- a/android-net/src/main/java/li/vin/net/SignInActivity.java
+++ b/android-net/src/main/java/li/vin/net/SignInActivity.java
@@ -114,6 +114,7 @@ public class SignInActivity extends Activity {
 
           try {
             pendingIntent.send(SignInActivity.this, 0, resultIntent);
+            finish();
           } catch (Exception e) {
             Log.d(TAG, "pending intent send error: " + e);
           }


### PR DESCRIPTION
As SignInActivity is opened when calls Vinli.signIn, the activity should also be closed by the library after a successfully signin. Here I'm having problems because I can signin with success, but the SignInActivity stays open.
First I was trying to execute Vinli.signIn with a pending intent created by PendingIntent.getBroadcast. My goal was to keep the same activity opened and receive a intent after Vinli signin.
````
 @OnClick(R.id.add_vinli_vehicle)
 void onAddVinliVehicleClick() {
   PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_VINLI_SIGNIN), 0);
   Vinli.signIn(this, getString(R.string.vinli_client_id), getString(R.string.vinli_redirect_uri), pendingIntent);
}
````
````
broadcastReceiver = new BroadcastReceiver() {
  @Override
  public void onReceive(Context context, Intent intent) {
    switch(intent.getAction()) {
      case ACTION_VINLI_SIGNIN:
        listVinliVehicles(intent);
        break;
    }
  }
};
IntentFilter intentFilter = new IntentFilter(ACTION_VINLI_SIGNIN);
registerReceiver(broadcastReceiver, intentFilter);
````
The code above works fine and receives the broadcast with ACTION_VINLI_SIGNIN, but the SignInActivity stays opened.

After that, with no succes, i tried to follow the example you provided executing Vinli.signIn with a pending intent created with PendingIntent.getActivity.
````
@OnClick(R.id.add_vinli_vehicle)
void onAddVinliVehicleClick() {
  PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, new Intent(this, VinliSigninSuccessActivity.class), 0);
  Vinli.signIn(this, getString(R.string.vinli_client_id), getString(R.string.vinli_redirect_uri), pendingIntent);
}
````
````
public class VinliSigninSuccessActivity extends ClosicActivity {
  public static final String ACTION_VINLI_SIGNIN = "com.closic.intent.action.VINLI_SIGNIN";
  @Override
  protected void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);
    Intent intent = new Intent(ACTION_VINLI_SIGNIN);
    intent.putExtras(getIntent());
    finish();
  }
}
````
The code above also is not working and the SignInActivity stays opened.
I think you can improve your library including a finish call after signin.